### PR TITLE
[BUGFIX] Settings.yml still needed at the moment. Missing line added

### DIFF
--- a/Documentation/Settings.yml
+++ b/Documentation/Settings.yml
@@ -1,0 +1,32 @@
+# This is the project specific Settings.yml file.
+# Place Sphinx specific build information here.
+# Settings given here will replace the settings of 'conf.py'.
+
+# Below is an example of intersphinx mapping declaration
+# Add more mappings depending on what manual you want to link to
+# Remove entirely if you don't need cross-linking
+
+---
+conf.py:
+  copyright: 2016
+  project: Simple FAQ
+  version: 1.0.3
+  release: 1.0.3
+  intersphinx_mapping:
+    t3tsref:
+    - http://docs.typo3.org/typo3cms/TyposcriptReference/
+    - null
+  latex_documents:
+  - - Index
+    - ehfaq.tex
+    - Simple FAQ
+    - Elmar Hinz
+    - manual
+  latex_elements:
+    papersize: a4paper
+    pointsize: 10pt
+    preamble: \usepackage
+  html_theme_options:
+    github_repository: TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual
+    github_branch: latest
+...


### PR DESCRIPTION
Line 18 had been missing ( - null) before. That was a fatal error and the reason
why the manual didn't render.

 15 intersphinx_mapping:
 16    t3tsref:
 17    - http://docs.typo3.org/typo3cms/TyposcriptReference/
 18    - null

It's good to be well prepared and have the Settings.cfg already.
But at the moment the Settings.yml ist still needed.
